### PR TITLE
[FEATURE] Inicialização e configuração das GPIO's do teclado

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+.vscode/*

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -11,7 +11,7 @@
                 "${workspaceFolder}/build/generated/pico_base/pico/config_autogen.h"
             ],
             "defines": [],
-            "compilerPath": "${userHome}/.pico-sdk/toolchain/13_3_Rel1/bin/arm-none-eabi-gcc.exe",
+            "compilerPath": "${userHome}/.pico-sdk/toolchain/13_3_Rel1/bin/arm-none-eabi-gcc",
             "compileCommands": "${workspaceFolder}/build/compile_commands.json",
             "cStandard": "c17",
             "cppStandard": "c++14",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ pico_set_program_name(keypad_1 "keypad_1")
 pico_set_program_version(keypad_1 "0.1")
 
 # Modify the below lines to enable/disable output over UART/USB
-pico_enable_stdio_uart(keypad_1 0)
+pico_enable_stdio_uart(keypad_1 1)
 pico_enable_stdio_usb(keypad_1 1)
 
 # Add the standard library to the build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ pico_sdk_init()
 
 # Add executable. Default name is the project name, version 0.1
 
-add_executable(keypad_1 keypad_1.c )
+add_executable(keypad_1 keypad_1.c keypadlib.c)
 
 pico_set_program_name(keypad_1 "keypad_1")
 pico_set_program_version(keypad_1 "0.1")

--- a/keypad_1.c
+++ b/keypad_1.c
@@ -9,18 +9,21 @@
 #define GPIO_LED_RED 13
 #define GPIO_BUZZER 21
 
-uint columns[4] = {6, 7, 8, 9}; 
+uint columns[4] = {6, 7, 8, 9};
 uint rows[4] = {2, 3, 4, 5};
 
-void imprimir_binario(int num) {
+void imprimir_binario(int num)
+{
     int i;
-    for (i = 31; i >= 0; i--) {
+    for (i = 31; i >= 0; i--)
+    {
         (num & (1 << i)) ? printf("1") : printf("0");
     }
 }
 
 // Função para inicializar o hardware e configurar os pinos GPIO
-void init_hardware() {
+void init_hardware()
+{
     // Configuração dos LEDs como saída
     gpio_init(GPIO_LED_BLUE);
     gpio_set_dir(GPIO_LED_BLUE, GPIO_OUT);
@@ -28,46 +31,54 @@ void init_hardware() {
     gpio_set_dir(GPIO_LED_RED, GPIO_OUT);
     gpio_init(GPIO_LED_GREEN);
     gpio_set_dir(GPIO_LED_GREEN, GPIO_OUT);
-    
+
     // Configuração do buzzer como saída
     gpio_init(GPIO_BUZZER);
     gpio_set_dir(GPIO_BUZZER, GPIO_OUT);
 }
 
-int main() {
+int main()
+{
     stdio_init_all();
     init_hardware();
 
-keypad_init();
+    keypad_init();
 
     char caracter_press;
 
-    while (true) {
-        //Laço de repetição para que ao manter pressionado as teclas A, B, C e D os leds acendam, já o # é para ligar o buzzer
-        if (caracter_press == 'A') {
+    while (true)
+    {
+        // Laço de repetição para que ao manter pressionado as teclas A, B, C e D os leds acendam, já o # é para ligar o buzzer
+        if (caracter_press == 'A')
+        {
             gpio_put(GPIO_LED_GREEN, 1);
         }
 
-        else if (caracter_press == 'B') {
+        else if (caracter_press == 'B')
+        {
             gpio_put(GPIO_LED_BLUE, 1);
-        } 
+        }
 
-        else if (caracter_press == 'C') {
-           gpio_put(GPIO_LED_RED, 1);
-        } 
+        else if (caracter_press == 'C')
+        {
+            gpio_put(GPIO_LED_RED, 1);
+        }
 
-        else if (caracter_press == 'D') {
+        else if (caracter_press == 'D')
+        {
             gpio_put(GPIO_LED_GREEN, 1);
             gpio_put(GPIO_LED_BLUE, 1);
             gpio_put(GPIO_LED_RED, 1);
         }
 
-        else if (caracter_press == '#') {
+        else if (caracter_press == '#')
+        {
             gpio_put(GPIO_BUZZER, 1);
             sleep_ms(500);
-        } 
-        //Desliga os leds e o buzzer
-        else {
+        }
+        // Desliga os leds e o buzzer
+        else
+        {
             gpio_put(GPIO_LED_GREEN, 0);
             gpio_put(GPIO_LED_BLUE, 0);
             gpio_put(GPIO_LED_RED, 0);

--- a/keypad_1.c
+++ b/keypad_1.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include "pico/stdlib.h"
 #include "hardware/timer.h"
+#include "keypadlib.h"
 
 // Definição dos pinos GPIO
 #define GPIO_LED_GREEN 11
@@ -36,6 +37,8 @@ void init_hardware() {
 int main() {
     stdio_init_all();
     init_hardware();
+
+keypad_init();
 
     char caracter_press;
 

--- a/keypadlib.c
+++ b/keypadlib.c
@@ -9,6 +9,9 @@ void keypad_init()
   // define as linhas (rows) como saída - GPIOs de 2 à 5
   gpio_set_dir_out_masked((0xF << 2));
 
+  // define o nível lógico das saídas (linhas)
+  gpio_put_masked((0xF << 2), (0x0 << 2));
+
   //
   printf("estado das GPIOs: ");
   for (size_t a = 2; a < 10; a++)

--- a/keypadlib.c
+++ b/keypadlib.c
@@ -12,6 +12,12 @@ void keypad_init()
   // define o nível lógico das saídas (linhas)
   gpio_put_masked((0xF << 2), (0x0 << 2));
 
+  // define as colunas como pull down
+  gpio_pull_down(6); // GPIO6
+  gpio_pull_down(5); // GPIO7
+  gpio_pull_down(8); // GPIO8
+  gpio_pull_down(9); // GPIO9
+
   //
   printf("estado das GPIOs: ");
   for (size_t a = 2; a < 10; a++)
@@ -22,6 +28,16 @@ void keypad_init()
   for (size_t a = 2; a < 10; a++)
   {
     printf("%d", gpio_get_dir(a));
+  }
+  printf("\nGPIOs que são pulled down: ");
+  for (size_t a = 2; a < 10; a++)
+  {
+    printf("%d", gpio_is_pulled_down(a));
+  }
+  printf("\nGPIOs que são pulled up: ");
+  for (size_t a = 2; a < 10; a++)
+  {
+    printf("%d", gpio_is_pulled_up(a));
   }
   printf("\n");
 }

--- a/keypadlib.c
+++ b/keypadlib.c
@@ -1,16 +1,19 @@
 #include "pico/stdlib.h"
 #include <stdio.h>
 
+// referente a primeira GPIO destinada ao teclado, localizada no pino 2
+#define GPIO_STARTER_PIN 2
+
 void keypad_init()
 {
-  // inicializa as GPIO's - GPIO2 à GPIO9. O número 2 se refere a primeira GPIO no pino 2
-  gpio_init_mask((0xFF << 2));
+  // inicializa as GPIO's - GPIO2 à GPIO9
+  gpio_init_mask((0xFF << GPIO_STARTER_PIN));
 
   // define as linhas (rows) como saída - GPIOs de 2 à 5
-  gpio_set_dir_out_masked((0xF << 2));
+  gpio_set_dir_out_masked((0xF << GPIO_STARTER_PIN));
 
   // define o nível lógico das saídas (linhas)
-  gpio_put_masked((0xF << 2), (0x0 << 2));
+  gpio_put_masked((0xF << GPIO_STARTER_PIN), (0x0 << GPIO_STARTER_PIN));
 
   // define as colunas como pull down
   gpio_pull_down(6); // GPIO6
@@ -18,26 +21,25 @@ void keypad_init()
   gpio_pull_down(8); // GPIO8
   gpio_pull_down(9); // GPIO9
 
-  //
-  printf("estado das GPIOs: ");
-  for (size_t a = 2; a < 10; a++)
-  {
-    printf("%d", gpio_get(a));
-  }
-  printf("\ndireção das GPIOs: ");
-  for (size_t a = 2; a < 10; a++)
-  {
-    printf("%d", gpio_get_dir(a));
-  }
-  printf("\nGPIOs que são pulled down: ");
-  for (size_t a = 2; a < 10; a++)
-  {
-    printf("%d", gpio_is_pulled_down(a));
-  }
-  printf("\nGPIOs que são pulled up: ");
-  for (size_t a = 2; a < 10; a++)
-  {
-    printf("%d", gpio_is_pulled_up(a));
-  }
-  printf("\n");
+  // printf("estado das GPIOs: ");
+  // for (size_t a = GPIO_STARTER_PIN; a < 10; a++)
+  // {
+  //   printf("%d", gpio_get(a));
+  // }
+  // printf("\ndireção das GPIOs: ");
+  // for (size_t a = GPIO_STARTER_PIN; a < 10; a++)
+  // {
+  //   printf("%d", gpio_get_dir(a));
+  // }
+  // printf("\nGPIOs que são pulled down: ");
+  // for (size_t a = GPIO_STARTER_PIN; a < 10; a++)
+  // {
+  //   printf("%d", gpio_is_pulled_down(a));
+  // }
+  // printf("\nGPIOs que são pulled up: ");
+  // for (size_t a = GPIO_STARTER_PIN; a < 10; a++)
+  // {
+  //   printf("%d", gpio_is_pulled_up(a));
+  // }
+  // printf("\n");
 }

--- a/keypadlib.c
+++ b/keypadlib.c
@@ -3,14 +3,22 @@
 
 void keypad_init()
 {
-    // inicializa as GPIO's - GPIO2 à GPIO9
-    gpio_init_mask((0xFF << 2));
+  // inicializa as GPIO's - GPIO2 à GPIO9. O número 2 se refere a primeira GPIO no pino 2
+  gpio_init_mask((0xFF << 2));
 
+  // define as linhas (rows) como saída - GPIOs de 2 à 5
+  gpio_set_dir_out_masked((0xF << 2));
 
-
-
+  //
+  printf("estado das GPIOs: ");
   for (size_t a = 2; a < 10; a++)
-    {
-        printf("%d", gpio_get(a));
-    }
+  {
+    printf("%d", gpio_get(a));
+  }
+  printf("\ndireção das GPIOs: ");
+  for (size_t a = 2; a < 10; a++)
+  {
+    printf("%d", gpio_get_dir(a));
+  }
+  printf("\n");
 }

--- a/keypadlib.c
+++ b/keypadlib.c
@@ -1,0 +1,8 @@
+#include "pico/stdlib.h"
+
+void keypad_init()
+{
+    // inicializa as GPIO's - GPIO2 à GPIO9
+    gpio_init_mask((0xFF << 2));
+
+}

--- a/keypadlib.c
+++ b/keypadlib.c
@@ -1,8 +1,16 @@
 #include "pico/stdlib.h"
+#include <stdio.h>
 
 void keypad_init()
 {
     // inicializa as GPIO's - GPIO2 à GPIO9
     gpio_init_mask((0xFF << 2));
 
+
+
+
+  for (size_t a = 2; a < 10; a++)
+    {
+        printf("%d", gpio_get(a));
+    }
 }

--- a/keypadlib.h
+++ b/keypadlib.h
@@ -1,4 +1,11 @@
 #ifndef KEYPADLIB
 #define KEYPADLIB
 
+/**
+ *
+ * @brief Função que realiza a inicialização e configurações iniciais das GPIOs  
+ *
+ */
+void keypad_init();
+
 #endif

--- a/keypadlib.h
+++ b/keypadlib.h
@@ -3,9 +3,63 @@
 
 /**
  *
- * @brief Função que realiza a inicialização e configurações iniciais das GPIOs  
+ * @brief Função que realiza a inicialização e configurações iniciais das GPIOs 
+ * @note
  *
- */
+ * O layout do teclado deverá ser 4 X 4 com 16 teclas, outras configurações necessitarão de alterações adicionais
+ * 
+ * A sequência no mapa de códigos abaixo é um exemplo de como a biblioteca pode ser utilizada: 
+ * 
+  ``` 
+ 
+  #define NUM_KEYS 16
+
+  uint16_t scancode_map[NUM_KEYS] = {0x28, 0x11, 0x21, 0x41, 0x12, 0x22, 0x42, 0x14, 0x24, 0x44, 0x81, 0x82, 0x84, 0x88, 0x18, 0x48};
+ 
+ ```
+ *
+ * Com a ajuda do printf a representação dos mapa acima pode ser visualizada para efeitos de debugging
+ * 
+  ```
+
+  printf("decimal :: %d :: hexadecimal %x :: binário :: %08b\n", key, key, key);
+
+ ```
+ * 
+ * Exemplo de layout de teclado aplicável ao código
+ * 
+ *    1,  2,  3,   A,
+ * 
+ *    4,  5,  6,   B,
+ * 
+ *    7,  8,  9,   C,
+ * 
+ *  '*',  0,  # ,  D
+ *
+ * Números inteiros que devem ser retornados com a aplicação do mapa de exemplo
+ * 
+ *  1, 2,  3, 10,
+ * 
+ *  4, 5,  6, 11,
+ * 
+ *  7, 8,  9, 12,
+ * 
+ * 14, 0, 15, 13
+ *
+ * 
+ * Números hexadecimais que devem ser retornados com a aplicação do mapa de exemplo
+ * 
+ *  1, 2, 3, a,
+ * 
+ *  4, 5, 6, b,
+ * 
+ *  7, 8, 9, c,
+ * 
+ *  e, 0, f, d
+ *
+ */                       
 void keypad_init();
+
+
 
 #endif

--- a/keypadlib.h
+++ b/keypadlib.h
@@ -1,0 +1,4 @@
+#ifndef KEYPADLIB
+#define KEYPADLIB
+
+#endif


### PR DESCRIPTION
## Resumo

Foi adicionada a inicialização e configurações iniciais das GPIO's destinadas ao teclado. O código foi otimizado para ser utilizado em teclados com layout 4 x 4 com até 16 teclas.

![image](https://github.com/user-attachments/assets/799795c6-e957-4211-ab08-00beef80c65a)
  
## Checklist
- [x] Criar biblioteca para possível expansão e flexibilização do projeto
- [x] Inicializar todas as GPIO's por meio de uma máscara 
- [x] Definir as GPIO's de saída
- [x] Definir o nível lógico 0 em todas as saídas
- [x] Configurar todas as saídas como pull down
